### PR TITLE
Feature/read len amplicon

### DIFF
--- a/perl/bin/cgpVaf.pl
+++ b/perl/bin/cgpVaf.pl
@@ -185,7 +185,7 @@ sub option_builder {
                 'dp|depth=s' => \$options{'dp'},
                 'hdr|high_depth_bed=s' => \$options{'hdr'},
                 'pid|id_int_project=s' => \$options{'pid'},
-                'exp|exonerate_percent=i' => \$options{'exp'},
+                'exp|exonerate_pct=i' => \$options{'exp'},
                 'vcf|vcf_files=s{,}' => \@{$options{'vcf'}},
                 'dbg|debug=i' => \$options{'dbg'},
                 'v|version'  => \$options{'v'}

--- a/perl/bin/cgpVaf.pl
+++ b/perl/bin/cgpVaf.pl
@@ -86,6 +86,7 @@ try {
 		'tabix_hdr' 	=> defined $vcf_obj->{'_hdr'}?Bio::DB::HTS::Tabix->new(filename => $vcf_obj->{'_hdr'}):undef,
 		'mq' 					=> $vcf_obj->{'_mq'},
 		'bq' 					=> $vcf_obj->{'_bq'},
+		'exp'                   =>  $vcf_obj->{'_exp'},
 		);	
 		
 	my($bed_locations)=$vcf_obj->getBedHash;
@@ -184,6 +185,7 @@ sub option_builder {
                 'dp|depth=s' => \$options{'dp'},
                 'hdr|high_depth_bed=s' => \$options{'hdr'},
                 'pid|id_int_project=s' => \$options{'pid'},
+                'exp|exonerate_percent=i' => \$options{'exp'},
                 'vcf|vcf_files=s{,}' => \@{$options{'vcf'}},
                 'dbg|debug=i' => \$options{'dbg'},
                 'v|version'  => \$options{'v'}
@@ -201,9 +203,9 @@ sub option_builder {
 	pod2usage(q{'-a' variant type must be defined}) unless (defined $options{'a'});
 	pod2usage(q{'-tn' toumour sample name/s must be provided}) unless (defined $options{'tn'});
 	pod2usage(q{'-nn' normal sample name/s must be provided}) unless (defined $options{'nn'});
-  pod2usage(q{'-e' Input vcf file extension must be provided}) unless (defined $options{'e'});
+    pod2usage(q{'-e' Input vcf file extension must be provided}) unless (defined $options{'e'});
 	pod2usage(q{'-b' bed file must be specified }) unless (defined $options{'b'} || defined $options{'e'});
-  pod2usage(q{'-o' Output folder must be provided}) unless (defined $options{'o'});
+    pod2usage(q{'-o' Output folder must be provided}) unless (defined $options{'o'});
 
 
 	if(!defined $options{'bo'}) { $options{'bo'}=0;}
@@ -241,6 +243,10 @@ sub option_builder {
 	if(!defined $options{'s'}) {
 		#analyse single sample no merge step 
 		$options{'s'}=undef;
+	}
+	if(!defined $options{'exp'}) {
+		#analyse single sample no merge step 
+		$options{'exp'}=92;
 	}
 	if(!defined $options{'ao'}) {
 		# augment vcf no merging step
@@ -293,6 +299,7 @@ cgpVaf.pl [-h] -d -a -g -tn -nn -e  -o [ -b -t -c -r -m -ao -mq -pid -bo -vcf -v
    --augment_only   (-ao) Only augment pindel VCF file (-m must be specified) [ do not  merge input files and add non passed varinats to output file ] (default 0: augment and merge )
    --map_quality    (-mq) read mapping quality threshold
    --base_quality   (-bq) base quality threshold for snp
+   --exonerate_pct  (exp) report alignment over a percentage of the maximum score attainable by each query (exonerate specific parameter) [default 92]
    --bamExtension   (-be) Input read file extension  
    --depth          (-dp) comma separated list of field(s) as specified in FORMAT field representing total depth at given location
    --high_depth_bed (-hdr) High Depth Region(HDR) bed file (tabix indexed) to mask high depth regions in the genome

--- a/perl/bin/cgpVaf.pl
+++ b/perl/bin/cgpVaf.pl
@@ -245,7 +245,7 @@ sub option_builder {
 		$options{'s'}=undef;
 	}
 	if(!defined $options{'exp'}) {
-		#analyse single sample no merge step 
+	#default exonerate percentage
 		$options{'exp'}=92;
 	}
 	if(!defined $options{'ao'}) {
@@ -299,7 +299,7 @@ cgpVaf.pl [-h] -d -a -g -tn -nn -e  -o [ -b -t -c -r -m -ao -mq -pid -bo -vcf -v
    --augment_only   (-ao) Only augment pindel VCF file (-m must be specified) [ do not  merge input files and add non passed varinats to output file ] (default 0: augment and merge )
    --map_quality    (-mq) read mapping quality threshold
    --base_quality   (-bq) base quality threshold for snp
-   --exonerate_pct  (exp) report alignment over a percentage of the maximum score attainable by each query (exonerate specific parameter) [default 92]
+   --exonerate_pct  (-exp) report alignment over a percentage of the maximum score attainable by each query (exonerate specific parameter) [default 92]
    --bamExtension   (-be) Input read file extension  
    --depth          (-dp) comma separated list of field(s) as specified in FORMAT field representing total depth at given location
    --high_depth_bed (-hdr) High Depth Region(HDR) bed file (tabix indexed) to mask high depth regions in the genome

--- a/perl/lib/Sanger/CGP/Vaf/Data/ReadVcf.pm
+++ b/perl/lib/Sanger/CGP/Vaf/Data/ReadVcf.pm
@@ -439,11 +439,6 @@ sub _getOriginalHeader {
 	foreach my $sample_line ( @$sample_info) {
 		foreach my $key (keys %$sample_line) {
 			if(defined $sample_line->{$key} and $key eq "SampleName") {
-				#if (exists $sample_line->{'CGP_Project'}) {
-				#	$self->_createSymlink($Sanger::CGP::Vaf::VafConstants::NST_LINKS.'/'.$sample_line->{'CGP_Project'}.'/'.$sample_line->{$key}.'/'.$sample_line->{$key}.'.bam',"$self->{'_d'}/$sample_line->{$key}.bam");
-				#	$self->_createSymlink($Sanger::CGP::Vaf::VafConstants::NST_LINKS.'/'.$sample_line->{'CGP_Project'}.'/'.$sample_line->{$key}.'/'.$sample_line->{$key}.'.bam',"$self->{'_d'}/$sample_line->{$key}.bam");
-				#	$log->debug("Created symlink for sample in vcf header: $sample_line->{$key} in project:".$sample_line->{'CGP_Project'});
-				#}
 				$normal_sample->{$sample_line->{$key}}.="|$sample";
 			}
 		}		
@@ -751,7 +746,7 @@ sub processMergedLocations {
 			if($self->{'_a'} eq 'indel') {	
 				$g_pu=$variant->getIndelResults($bam_objects->{$sample},$g_pu);
 				if( ($sample eq $self->getNormalName) && (defined $self->{'_m'}) ) {
-					$g_pu=$variant->addNormalCount($g_pu);
+					$g_pu=$variant->addNormalCount($g_pu);					
 				}
 				elsif($self->{'_m'} && $data_for_all_samples->{$sample}{$location}) {
 					$store_results=$variant->storeResults($store_results,$g_pu,$sample);
@@ -931,7 +926,7 @@ sub _get_read_length {
 				$read_counter++;
 				my $len=length($qseq);
 				$mapped_length->{$len}=$read_counter;
-				if($read_counter > 100){
+				if($read_counter > 1000){
 					return $mapped_length;
 				}
 			}
@@ -1053,7 +1048,7 @@ sub _getVCFObject {
 	
 	return $vcf;
 }
-
+	
 =head2 _get_tab_sep_header
 parse header data to generate header data and columns names
 Inputs

--- a/perl/lib/Sanger/CGP/Vaf/Process/Variant.pm
+++ b/perl/lib/Sanger/CGP/Vaf/Process/Variant.pm
@@ -765,7 +765,7 @@ sub _do_exonerate {
 	my $read_track_alt;
 	my $read_track_ref;
 	my $amb_reads;
-	my $test_mode=0;
+	my $test_mode=1;
 	
 	#print Dumper $g_pu;
  # -E | --exhaustive <boolean>
@@ -775,14 +775,14 @@ sub _do_exonerate {
   # using exhaustive OFF as it is fast and gives identical answer 
   
   my $cmd="exonerate -E 0 -S 0".
-	"   --percent 92 --fsmmemory 12000 --verbose 0 --showalignment no  --wordjump 3".
+	"   --percent $self->{'_exp'} --fsmmemory 12000 --verbose 0 --showalignment no  --wordjump 3".
 	" --querytype dna --targettype dna --query $temp_read_file  --target $ref_seq_file".
 	" --showvulgar 0 --bestn 1 --ryo '%qi %ti %qal %tS %tab %tae %qS %em {%Ps}\n' ";
 	#for testing only
 	if($test_mode)
 	{
 	  my $cmd2="exonerate -E 0 -S 0".
-		"  --percent 92 --fsmmemory 12000 --verbose 0 --showalignment yes --wordjump 3".
+		"  --percent $self->{'_exp'} --fsmmemory 12000 --verbose 0 --showalignment yes --wordjump 3".
 		" --querytype dna --targettype dna --query $temp_read_file   --target $ref_seq_file".
 		" --showvulgar 0 --bestn 1 --ryo '%qi %ti %qal %tS %tab %tae %qS\n' ";
 		print "$cmd2\n";

--- a/perl/lib/Sanger/CGP/Vaf/Process/Variant.pm
+++ b/perl/lib/Sanger/CGP/Vaf/Process/Variant.pm
@@ -770,7 +770,7 @@ sub _do_exonerate {
 	my $read_track_alt;
 	my $read_track_ref;
 	my $amb_reads;
-	my $test_mode=1;
+	my $test_mode=0;
 	
 	#print Dumper $g_pu;
  # -E | --exhaustive <boolean>

--- a/perl/lib/Sanger/CGP/Vaf/Process/Variant.pm
+++ b/perl/lib/Sanger/CGP/Vaf/Process/Variant.pm
@@ -353,9 +353,14 @@ sub _getRange {
 	}else{
 		$log->logcroak("Library size or chromosome length in not defined");
 	}
-	
-	$g_pu->{'pos_5p'}=round($left_pos - $lib_size);
-	$g_pu->{'pos_3p'}=round($right_pos + $lib_size);
+	if(!defined $lib_size) {
+	 $g_pu->{'pos_5p'}=round($left_pos - 200);
+	 $g_pu->{'pos_3p'}=round($right_pos + 200);
+	  
+	}else{
+	 $g_pu->{'pos_5p'}=round($left_pos - $lib_size);
+	 $g_pu->{'pos_3p'}=round($right_pos + $lib_size);
+	}
 	$g_pu->{'hdr'}=$hdr_flag;
 	# to get exact location of variant base and avoid borderline matching   
 	# added padding to reference posotion 

--- a/perl/run_test.sh
+++ b/perl/run_test.sh
@@ -1,1 +1,1 @@
-/software/perl-5.16.3/bin/prove -v -I lib -I /nfs/users/nfs_s/sb43/software/vafCorrect_4.4.1/lib/perl5/
+/software/perl-5.16.3/bin/prove -v -I lib 


### PR DESCRIPTION
a) Removed criteria to filter alignments below certain threshold score [ calculated based on read length]
b) removed condition to discard alignment length smaller than read length [2bp grace]
 
Ticket #588189 : Amplicon data is not handled correctly
a) Increased padding [+library size] to fetch reference sequence -- this will allow to map longer reads in amplicon data.

Added option to provide exonerate precent cutoff value